### PR TITLE
fix wonky -o

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -43,35 +43,36 @@ export default yargs => {
     // The magic
     // ------------------------------------------------------------------------
     const scaffoldName = argv._[1]
+    const out = argv._[2] ? argv._[2] : argv.out
     const scaffold = resolve(SCAFFOLD_DIR, scaffoldName)
     const pack = resolve(scaffold, 'package.json')
 
-    canOverwrite(argv.out)
+    canOverwrite(out)
         .then(can => {
             if (!can) throw new Error('Refusing to overwrite existing directory.')
         })
-        .then(() => spawn('rm', ['-rf', resolve(argv.out)]))
-        .then(() => spawn('mkdir', ['-p', resolve(argv.out)]))
-        .then(() => copy(pack, resolve(argv.out)))
+        .then(() => spawn('rm', ['-rf', resolve(out)]))
+        .then(() => spawn('mkdir', ['-p', resolve(out)]))
+        .then(() => copy(pack, resolve(out)))
         .then(() => spawn('npm', ['init'], {
-            cwd: resolve(argv.out),
+            cwd: resolve(out),
             stdio: [process.stdin, process.stdout]
         }))
         .then(() => {
             process.stdout.write('\ninstalling devDependencies...')
 
             return spawn('npm', ['install'], {
-                cwd: resolve(argv.out),
+                cwd: resolve(out),
                 stdio: [process.stdin, process.stdout]
             })
         })
-        .then(() => read(resolve(argv.out, 'package.json')))
+        .then(() => read(resolve(out, 'package.json')))
         .then(JSON.parse)
         .then(options => generator([
             scaffold + '/**/*',
             scaffold + '/**/.*',
             '!**/package.json'
-        ], options, argv.out))
+        ], options, out))
         .then(out => {
             process.stdout.write(
 `

--- a/src/util/can-overwrite.js
+++ b/src/util/can-overwrite.js
@@ -1,15 +1,15 @@
 import {access, F_OK} from 'fs'
 import inquirer from 'inquirer'
 
-const questionOverwrite = [{
+const questionOverwrite = dir => [{
     type: 'confirm',
     name: 'overwrite',
-    message: 'This directory already exists. Overwrite it?'
+    message: `${dir} already exists. Overwrite it?`
 }]
 
 export default (out) => new Promise(resolve => access(out, F_OK, e => {
     if (!e) {
-        inquirer.prompt(questionOverwrite, answers => {
+        inquirer.prompt(questionOverwrite(out), answers => {
             if (!answers.overwrite) {
                 resolve(false)
             } else {

--- a/src/util/can-overwrite.js
+++ b/src/util/can-overwrite.js
@@ -1,10 +1,12 @@
 import {access, F_OK} from 'fs'
+import {resolve} from 'path'
 import inquirer from 'inquirer'
 
 const questionOverwrite = dir => [{
     type: 'confirm',
     name: 'overwrite',
-    message: `${dir} already exists. Overwrite it?`
+    default: false,
+    message: `${resolve(dir)} already exists. Overwrite it?`
 }]
 
 export default (out) => new Promise(resolve => access(out, F_OK, e => {


### PR DESCRIPTION
valid ways to init:
```
jscli init web-app my-app
jscli init web-app -o my-app
jscli init web-app # init in current directory
```